### PR TITLE
Drop `runFold`

### DIFF
--- a/src/Clang/HighLevel/Types.hs
+++ b/src/Clang/HighLevel/Types.hs
@@ -28,7 +28,6 @@ module Clang.HighLevel.Types (
     -- ** Construction
   , simpleFold
   , foldWithHandler
-  , runFold
     -- ** Fold-specific functionality
   , foldBreak
   , foldBreakWith


### PR DESCRIPTION
The contract of `runFold` promised

```hs
--- If the fold has an associated exception handler, it will get a chance to
--- catch any exceptions thrown. See 'foldWithHandler' for detailed discussion.
```

but that is a contract it could not keep: after all, the whole point for introducing `foldWithHandler` in the first place was that we need to treat these handlers very carefully, simply using `handle` does not work.

It turns out we don't actually _need_ `runFold`, so deleted it altogether; I think this clarifies the situation on the `hs-bindgen` side also (see discussion of `topLevelFold` there).