### PR TITLE
Dom/loosen bounds

### DIFF
--- a/libclang-bindings.cabal
+++ b/libclang-bindings.cabal
@@ -115,6 +115,8 @@ library
 
   build-tool-depends:
       hsc2hs:hsc2hs
+  extra-libraries:
+      clang
 
 executable clang-bootstrap
   import:         lang

--- a/libclang-bindings.cabal
+++ b/libclang-bindings.cabal
@@ -177,7 +177,7 @@ test-suite test-clang-bindings
   build-depends:
       -- New dependencies
     , containers       >= 0.6  && < 0.8
-    , QuickCheck       >= 2.15 && < 2.17
+    , QuickCheck       >= 2.14 && < 2.17
     , tasty            >= 1.5  && < 1.6
     , tasty-hunit      >= 0.10 && < 0.11
     , tasty-quickcheck >= 0.11 && < 0.12

--- a/libclang-bindings.cabal
+++ b/libclang-bindings.cabal
@@ -97,7 +97,7 @@ library
       Clang.HighLevel.Wrappers
   build-depends:
       -- External dependencies
-    , data-default  >= 0.8   && < 0.9
+    , data-default  >= 0.7   && < 0.9
     , exceptions    >= 0.10  && < 0.11
     , mtl           >= 2.2   && < 2.4
     , text          >= 1.2   && < 2.2


### PR DESCRIPTION
Required to build `libclang-bindings` (and `hs-bindgen`) with Stackage LTS 23 (which is the basis of Nix).