### PR TITLE
Refactor C standard types

### DIFF
--- a/libclang-bindings.cabal
+++ b/libclang-bindings.cabal
@@ -64,6 +64,7 @@ library
   exposed-modules:
     Clang.Args
     Clang.Backtrace
+    Clang.CStandard
     Clang.Enum.Bitfield
     Clang.Enum.Simple
     Clang.HighLevel

--- a/src/Clang/Args.hs
+++ b/src/Clang/Args.hs
@@ -1,19 +1,12 @@
 module Clang.Args (
     -- * Clang arguments
     ClangArgs(..)
-  , InvalidClangArgs
-    -- * C standard
-  , CStandard(..)
-  , Gnu(..)
-  , getStdClangArg
+  , InvalidClangArgs(..)
   ) where
 
 import Control.Exception (Exception)
 import Data.Default (Default (def))
 import Data.String (IsString)
-import Data.Text (Text)
-
-import Clang.Version
 
 {-------------------------------------------------------------------------------
   Clang arguments
@@ -38,65 +31,3 @@ newtype InvalidClangArgs = InvalidClangArgs String
   deriving stock (Show)
   deriving newtype (IsString)
   deriving anyclass (Exception)
-
-{-------------------------------------------------------------------------------
-  C standard
--------------------------------------------------------------------------------}
-
--- | C standard
---
--- Reference:
---
--- * "C Support in Clang"
---   <https://clang.llvm.org/c_status.html>
--- * "Differences between various standard modes" in the clang user manual
---   <https://clang.llvm.org/docs/UsersManual.html#differences-between-various-standard-modes>
-data CStandard =
-    C89
-  | C99
-  | C11
-  | C17
-  | C23
-  deriving stock (Bounded, Enum, Eq, Ord, Show)
-
--- | Enable GNU extensions?
-data Gnu =
-    DisableGnu
-  | EnableGnu
-  deriving stock (Bounded, Enum, Eq, Ord, Show)
-
--- | Get the Clang argument for the specified C standard
---
--- Support for C standards differ across different versions of Clang.
-getStdClangArg :: CStandard -> Gnu -> Either InvalidClangArgs String
-getStdClangArg cStandard gnu = case cStandard of
-    C89 -> standardOrGnu "-std=c89" "-std=gnu89"
-    C99 -> standardOrGnu "-std=c99" "-std=gnu99"
-    C11 -> case clangVersion of
-      ClangVersion version
-        | version < (3, 2, 0)     -> standardOrGnu "-std=c1x" "-std=gnu1x"
-        | otherwise               -> standardOrGnu "-std=c11" "-std=gnu11"
-      ClangVersionUnknown version -> unknownClangVersion version
-    C17 -> case clangVersion of
-      ClangVersion version
-        | version < (6, 0, 0)     -> invalid "C17 requires clang-6 or later"
-        | otherwise               -> standardOrGnu "-std=c17" "-std=gnu17"
-      ClangVersionUnknown version -> unknownClangVersion version
-    C23 -> case clangVersion of
-      ClangVersion version
-        | version < (9, 0, 0)     -> invalid "C23 requires clang-9 or later"
-        | version < (18, 0, 0)    -> standardOrGnu "-std=c2x" "-std=gnu2x"
-        | otherwise               -> standardOrGnu "-std=c23" "-std=gnu23"
-      ClangVersionUnknown version -> unknownClangVersion version
-  where
-    standardOrGnu :: String -> String -> Either a String
-    standardOrGnu argStandard argGnu = case gnu of
-      DisableGnu -> Right argStandard
-      EnableGnu  -> Right argGnu
-
-    invalid :: String -> Either InvalidClangArgs a
-    invalid = Left . InvalidClangArgs
-
-    unknownClangVersion :: Text -> Either InvalidClangArgs a
-    unknownClangVersion version = Left . InvalidClangArgs $
-      "Unknown clang version: " ++ show version

--- a/src/Clang/CStandard.hs
+++ b/src/Clang/CStandard.hs
@@ -1,0 +1,148 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Clang.CStandard (
+    -- * C standard
+    CStandard(..)
+  , Gnu(..)
+  , ClangCStandard(..)
+    -- * Querying @libclang@
+  , getClangCStandard
+  ) where
+
+import Data.Text (Text)
+import Data.Text qualified as Text
+
+import Clang.Args (ClangArgs)
+import Clang.Enum.Bitfield
+import Clang.Enum.Simple
+import Clang.HighLevel qualified as HighLevel
+import Clang.HighLevel.Types
+import Clang.Internal.Results
+import Clang.LowLevel.Core
+import Clang.Paths
+
+{-------------------------------------------------------------------------------
+  C standard
+-------------------------------------------------------------------------------}
+
+-- | C standard
+--
+-- Reference:
+--
+-- * "C Support in Clang"
+--   <https://clang.llvm.org/c_status.html>
+-- * "Differences between various standard modes" in the clang user manual
+--   <https://clang.llvm.org/docs/UsersManual.html#differences-between-various-standard-modes>
+data CStandard =
+    C89
+  | C95
+  | C99
+  | C11
+  | C17
+  | C23
+  deriving stock (Bounded, Enum, Eq, Ord, Show)
+
+-- | Enable GNU extensions?
+data Gnu =
+    DisableGnu
+  | EnableGnu
+  deriving stock (Bounded, Enum, Eq, Ord, Show)
+
+-- | Clang C standard
+data ClangCStandard = ClangCStandard {
+      cStandard :: CStandard
+    , gnu       :: Gnu
+    }
+  deriving (Eq, Ord, Show)
+
+{-------------------------------------------------------------------------------
+  Querying @libclang@
+-------------------------------------------------------------------------------}
+
+-- | Get the C standard for the specified 'ClangArgs'
+--
+-- Reference:
+--
+-- * <https://clang.llvm.org/docs/UsersManual.html#differences-between-various-standard-modes>
+-- * <https://gcc.gnu.org/onlinedocs/cpp/Standard-Predefined-Macros.html>
+getClangCStandard :: ClangArgs -> IO (Maybe ClangCStandard)
+getClangCStandard = fmap (aux =<<) . getClangCStandardBuiltinMacros
+  where
+    aux :: (Bool, Maybe Integer, Bool) -> Maybe ClangCStandard
+    aux (isStdc, mStdcVersion, isGnu)
+      | isStdc =
+          let gnu'       = if isGnu then EnableGnu else DisableGnu
+              valid std' = Just $ ClangCStandard std' gnu'
+          in  case mStdcVersion of
+                Nothing     -> valid C89
+                Just 199409 -> valid C95
+                Just 199901 -> valid C99
+                Just 201112 -> valid C11
+                Just 201710 -> valid C17  -- c17 6~
+                Just 202000 -> valid C23  -- c2x 14~17
+                Just 202311 -> valid C23  -- c23 18.1.0~
+                Just _other -> Nothing
+      | otherwise = Nothing
+
+-- | Get the values of builtin macros used to determine the C standard
+--
+-- This function gets the values for three macros:
+--
+-- 1. @__STDC__@ ('Bool'), used to detect C89
+-- 1. @__STDC_VERSION__@ ('Integer')
+-- 2. @linux@ ('Bool'), used to detect GNU extensions
+--
+-- 'Nothing' is returned if there is an error.
+getClangCStandardBuiltinMacros ::
+     ClangArgs
+  -> IO (Maybe (Bool, Maybe Integer, Bool))
+getClangCStandardBuiltinMacros clangArgs =
+    HighLevel.withUnsavedFile filename contents $ \unsavedFile ->
+      HighLevel.withIndex DontDisplayDiagnostics $ \index ->
+        HighLevel.withTranslationUnit2
+          index
+          (Just $ SourcePath (Text.pack filename))
+          clangArgs
+          [unsavedFile]
+          (bitfieldEnum [CXTranslationUnit_None])
+          (const $ return Nothing)
+          (fmap Just . process)
+  where
+    filename :: FilePath
+    filename = "libclang-bindings-version.h"
+
+    contents :: String
+    contents = unlines [
+        "const long long builtin_stdc = __STDC__;"
+      , "const long long builtin_stdc_version = __STDC_VERSION__;"
+      , "const long long builtin_linux = linux;"
+      ]
+
+    process :: CXTranslationUnit -> IO (Bool, Maybe Integer, Bool)
+    process unit = do
+      root <- clang_getTranslationUnitCursor unit
+      kvs  <- HighLevel.clang_visitChildren root visit
+      return
+        ( lookupBool    "builtin_stdc"         kvs
+        , lookupInteger "builtin_stdc_version" kvs
+        , lookupBool    "linux"                kvs
+        )
+
+    visit :: Fold IO (Text, EvalResult)
+    visit = simpleFold $ \curr -> do
+      kind <- clang_getCursorKind curr
+      case fromSimpleEnum kind of
+        Right CXCursor_VarDecl ->
+          clang_getCursorSpelling curr >>= \name ->
+            HighLevel.clang_evaluate curr >>= \case
+              Just er    -> foldContinueWith (name, er)
+              _otherwise -> foldContinue
+        _otherwise -> foldContinue
+
+    lookupInteger :: Text -> [(Text, EvalResult)] -> Maybe Integer
+    lookupInteger k kvs = case lookup k kvs of
+      Just (EvalResultInteger n) -> Just n
+      _otherwise                 -> Nothing
+
+    lookupBool :: Text -> [(Text, EvalResult)] -> Bool
+    lookupBool k = maybe False cToBool . lookupInteger k


### PR DESCRIPTION
We decided to always get the C standard from `libclang`.  Users may specify a Clang standard via Clang arguments.

The C standard code is therefore moved to `Clang.CStandard`.  (This is also necessary to avoid import cycles.)

Clang standards specify *both* the C standard and use of GNU extensions. New type `ClangCStandard` is the product of `CStandard` and `Gnu`. While these types should generally be specified together, it is convenient to case match them separately.

Support for `C95` (`iso9899:199409`) is added.  This library should support all *published* C standards that are supported by the latest supported version of `libclang`.

Function `getClangCStandard` queries `libclang` for the `ClangCStandard` using the specified `ClangArgs`.

Code for rendering Clang arguments for these types is removed.