### PR TITLE
Fix const warning (#21)

### DIFF
--- a/cbits/clang_wrappers.h
+++ b/cbits/clang_wrappers.h
@@ -267,7 +267,7 @@ static inline void wrap_disposeString(const CXString* string) {
  * Miscellaneous utility functions
  */
 
-static inline CXEvalResult wrap_Cursor_Evaluate(CXCursor* cursor) {
+static inline CXEvalResult wrap_Cursor_Evaluate(const CXCursor* cursor) {
     return clang_Cursor_Evaluate(*cursor);
 }
 


### PR DESCRIPTION
This commit fixes the `const` warning that happens when using older versions of GHC.  It does *not* ensure that such warnings result in CI failure, however, as we do not know of a good way to make that work.