### PR TITLE
Fix restore cache condition

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -36,7 +36,7 @@ on:
         required: true
       enable_cache:
         description: "Enable cache (restore and save)"
-        default: true
+        default: "true"
         required: true
       debug_tmate:
         description: "Debug with tmate after {init, checkout, setup, build, test}"
@@ -256,7 +256,7 @@ jobs:
 
       - name: "[setup] Restore cache"
         # Do not restore the cache if it is disabled in a manual dispatch.
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.enable_cache }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.enable_cache == 'true' }}
         id: restore-cache
         uses: actions/cache/restore@v4
         env:


### PR DESCRIPTION
**Manual Dispatch**

Navigating to the "Actions" tab and clicking on the "Windows tests" workflow in the list on the left brings you to the [Windows tests](https://github.com/well-typed/libclang/actions/workflows/windows.yml) workflow page.

There is a "Run workflow" button awkwardly placed in between the header and the table body.  Clicking on the button opens the options, and the green "Run workflow" button can be pressed to actually run the workflow.

------------------------------------------------------------------------------

For my test, I set the following options:

* Branch: `main`
* Versions: `"9.6","9.12"`
* Enable cache: `false`
* Debug with `tmate` after: `checkout`

The correct jobs are run, and both started the `tmate` sessions.

The "Restore cache" step ran, which is wrong.  The condition is as follows:

```
${{ github.event_name != 'workflow_dispatch' || inputs.enable_cache }}
```

I bet it is a boolean vs. string issue.  I am changing the condition to the following:

```
${{ github.event_name != 'workflow_dispatch' || inputs.enable_cache == 'true' }}
```

I am also changing the input configuration to quote `"true"` to emphasize that it is a string.