### PR TITLE
Fix restore cache condition (part two)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -276,7 +276,7 @@ jobs:
       - name: "[build] Save cache"
         # Do not save the cache if it is disabled in a manual dispatch or it
         # already exists.
-        if: ${{ (github.event_name != 'workflow_dispatch' || inputs.enable_cache) && (steps.restore-cache.outputs.cache-hit != 'true') }}
+        if: ${{ (github.event_name != 'workflow_dispatch' || inputs.enable_cache == 'true') && (steps.restore-cache.outputs.cache-hit != 'true') }}
         uses: actions/cache/save@v4
         with:
           path: ${{ steps.setup-haskell.outputs.cabal-store }}


### PR DESCRIPTION
Manual dispatch test:

* Branch: `main`
* Versions: `"9.10"`
* Enable cache: `false`
* Debug with `tmate` after: `off`

The "Restore cache" step is skipped, but now the "Save cache" is run and displays a warning that the key is not specified.  Of course, I somehow forgot to change the restore cache condition in the same way. :facepalm: