### PR TITLE
Silence `CXRemapping` deprecation from <clang-c> includes

### DIFF
--- a/libclang-bindings/CHANGELOG.md
+++ b/libclang-bindings/CHANGELOG.md
@@ -25,10 +25,16 @@
 
 ### Bug fixes
 
+* Silence `-Wdeprecated-declarations` warnings emitted by `<clang-c/Index.h>`
+  on Clang 21 at the system-header include sites only, so that deprecation
+  warnings for libclang APIs we actually call remain visible. See
+  [issue #58][issue-58].
+
 [pr-37]: https://github.com/well-typed/libclang/pull/37
 [pr-42]: https://github.com/well-typed/libclang/pull/42
 [pr-47]: https://github.com/well-typed/libclang/pull/47
 [pr-53]: https://github.com/well-typed/libclang/pull/53
+[issue-58]: https://github.com/well-typed/libclang/issues/58
 
 ## 0.1.0-alpha -- 2026-02-06
 

--- a/libclang-bindings/cbits/clang_wrappers.h
+++ b/libclang-bindings/cbits/clang_wrappers.h
@@ -1,7 +1,17 @@
 #ifndef CLANG_WRAPPERS_H
 #define CLANG_WRAPPERS_H
 
+#include "libclang_version.h"
+
+#if LIBCLANG_VERSION_MAJOR == 21
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 #include <clang-c/Index.h>
+#if LIBCLANG_VERSION_MAJOR == 21
+#pragma GCC diagnostic pop
+#endif
+
 #include <stdio.h>
 #include "clang_wrappers_ffi.h"
 

--- a/libclang-bindings/cbits/doxygen_wrappers.h
+++ b/libclang-bindings/cbits/doxygen_wrappers.h
@@ -1,6 +1,8 @@
 #ifndef DOXYGEN_WRAPPERS_H
 #define DOXYGEN_WRAPPERS_H
 
+#include "libclang_version.h"
+
 /**
  * Wrappers for the Doxygen API
  *
@@ -17,7 +19,14 @@
  * convention for such parameters, while `result` is not capitalized.
  */
 
+#if LIBCLANG_VERSION_MAJOR == 21
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 #include <clang-c/Documentation.h>
+#if LIBCLANG_VERSION_MAJOR == 21
+#pragma GCC diagnostic pop
+#endif
 
 /**
  * Top-level

--- a/libclang-bindings/cbits/rewrite_wrappers.h
+++ b/libclang-bindings/cbits/rewrite_wrappers.h
@@ -1,11 +1,20 @@
 #ifndef REWRITE_WRAPPERS_H
 #define REWRITE_WRAPPERS_H
 
+#include "libclang_version.h"
+
 /**
  * Wrappers for the Rewrite API
  */
 
+#if LIBCLANG_VERSION_MAJOR == 21
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 #include <clang-c/Rewrite.h>
+#if LIBCLANG_VERSION_MAJOR == 21
+#pragma GCC diagnostic pop
+#endif
 
 static inline void wrap_CXRewriter_insertTextBefore(CXRewriter Rew, const CXSourceLocation *Loc, const char *Insert) {
     clang_CXRewriter_insertTextBefore(Rew, *Loc, Insert);


### PR DESCRIPTION
Fixes #58