### PR TITLE
Support exception contexts in the Fold API

### DIFF
--- a/libclang-bindings.cabal
+++ b/libclang-bindings.cabal
@@ -102,6 +102,7 @@ library
     Clang.HighLevel.Wrappers
     Clang.Internal.ConstPtr
     Clang.Internal.CXString
+    Clang.Internal.Exception
     Clang.Internal.FFI
     Clang.Internal.Ptr
     Clang.Internal.Results

--- a/src/Clang/HighLevel/Fold.hs
+++ b/src/Clang/HighLevel/Fold.hs
@@ -26,7 +26,7 @@ module Clang.HighLevel.Fold (
   , clang_visitChildren
   ) where
 
-import Control.Exception (Exception (..), SomeException)
+import Control.Exception (Exception (..), ExceptionWithContext (..), SomeException)
 import Control.Exception qualified as Base
 import Control.Monad (forM_)
 import Control.Monad.IO.Class (MonadIO, liftIO)
@@ -313,18 +313,17 @@ instance Functor m => Functor (Fold m) where
   async exceptions or not.
 -------------------------------------------------------------------------------}
 
-throwIO :: (MonadIO m, Exception e) => e -> m a
-throwIO = liftIO . Base.throwIO
+throwIO :: MonadIO m => SomeException -> m a
+throwIO e = liftIO (Base.rethrowIO (ExceptionWithContext (Base.someExceptionContext e) e))
+
+try :: IO a -> IO (Either SomeException a)
+try m = Base.catchNoPropagate (Right <$> m) (\(ExceptionWithContext _ e) -> pure (Left e))
 
 type RunInIO m = forall a. m a -> IO a
 
-handleUnliftUsing ::
-     ( MonadIO n
-     , Exception e
-     )
-  => RunInIO m -> (e -> m a) -> m a -> n a
+handleUnliftUsing :: MonadIO n => RunInIO m -> (SomeException -> m a) -> m a -> n a
 handleUnliftUsing runInIO handler action = liftIO $
-    Base.handle (runInIO . handler) (runInIO action)
+    Base.catchNoPropagate (runInIO action) (\(ExceptionWithContext _ e) -> runInIO (handler e))
 
 {-------------------------------------------------------------------------------
   Internal: partial results
@@ -467,7 +466,7 @@ popUntil runInIO someStack newParent = do
             Push p summarize (stack' :: Stack m b) -> do
               let handler :: SomeException -> m (Maybe b)
                   handler = foldHandler (topFold stack') (parent p)
-              mb <- Base.try $
+              mb <- try $
                 handleUnliftUsing runInIO handler $
                   summarize =<< getPartialResults (partialResults p)
               case mb of
@@ -520,7 +519,7 @@ clang_visitChildren root topLevelFold = withRunInIO $ \runInIO -> do
         if previousException then
           return $ simpleEnum CXChildVisit_Continue
         else do
-          next <- Base.try $
+          next <- try $
             handleUnliftUsing runInIO (fmap Continue . foldHandler current) $
               foldNext current
           case next of

--- a/src/Clang/HighLevel/Fold.hs
+++ b/src/Clang/HighLevel/Fold.hs
@@ -26,8 +26,7 @@ module Clang.HighLevel.Fold (
   , clang_visitChildren
   ) where
 
-import Control.Exception (Exception (..), ExceptionWithContext (..), SomeException)
-import Control.Exception qualified as Base
+import Control.Exception (Exception (..), SomeException)
 import Control.Monad (forM_)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.IO.Unlift (MonadUnliftIO (withRunInIO))
@@ -35,6 +34,7 @@ import Data.IORef
 import GHC.Stack
 
 import Clang.Enum.Simple
+import Clang.Internal.Exception
 import Clang.LowLevel.Core hiding (clang_visitChildren)
 import Clang.LowLevel.Core qualified as Core
 
@@ -304,26 +304,6 @@ instance Functor m => Functor (Fold m) where
         foldNext    = \curr -> fmap (fmap f) $ foldNext curr
       , foldHandler = \curr -> fmap (fmap f) . foldHandler curr
       }
-
-{-------------------------------------------------------------------------------
-  Internal: exception handling
-
-  We do not use @handle@ from @unlift@, as it excludes async exceptions, and we
-  want it to be up to the exception handler to decide if it wants to deal with
-  async exceptions or not.
--------------------------------------------------------------------------------}
-
-throwIO :: MonadIO m => SomeException -> m a
-throwIO e = liftIO (Base.rethrowIO (ExceptionWithContext (Base.someExceptionContext e) e))
-
-try :: IO a -> IO (Either SomeException a)
-try m = Base.catchNoPropagate (Right <$> m) (\(ExceptionWithContext _ e) -> pure (Left e))
-
-type RunInIO m = forall a. m a -> IO a
-
-handleUnliftUsing :: MonadIO n => RunInIO m -> (SomeException -> m a) -> m a -> n a
-handleUnliftUsing runInIO handler action = liftIO $
-    Base.catchNoPropagate (runInIO action) (\(ExceptionWithContext _ e) -> runInIO (handler e))
 
 {-------------------------------------------------------------------------------
   Internal: partial results

--- a/src/Clang/Internal/Exception.hs
+++ b/src/Clang/Internal/Exception.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE CPP #-}
+module Clang.Internal.Exception
+  ( throwIO
+  , try
+  , RunInIO
+  , handleUnliftUsing
+  ) where
+
+import Control.Exception (SomeException)
+import Control.Exception qualified as Base
+import Control.Monad.IO.Class (MonadIO (..))
+
+{-------------------------------------------------------------------------------
+  Internal: exception handling
+
+  We do not use @handle@ from @unlift@, as it excludes async exceptions, and we
+  want it to be up to the exception handler to decide if it wants to deal with
+  async exceptions or not.
+-------------------------------------------------------------------------------}
+
+-- GHC 9.12 introduces `rethrowIO`, the `WhileHandling` annotation, and `catchNoPropagate`
+#if defined(MIN_VERSION_GLASGOW_HASKELL) && MIN_VERSION_GLASGOW_HASKELL(9, 12, 0, 0)
+
+throwIO :: MonadIO m => SomeException -> m a
+throwIO e = liftIO (Base.rethrowIO (Base.ExceptionWithContext (Base.someExceptionContext e) e))
+
+try :: IO a -> IO (Either SomeException a)
+try m = Base.catchNoPropagate (Right <$> m) (\(Base.ExceptionWithContext _ e) -> pure (Left e))
+
+type RunInIO m = forall a. m a -> IO a
+
+handleUnliftUsing :: MonadIO n => RunInIO m -> (SomeException -> m a) -> m a -> n a
+handleUnliftUsing runInIO handler action = liftIO $
+    Base.catchNoPropagate (runInIO action) (\(Base.ExceptionWithContext _ e) -> runInIO (handler e))
+
+#else
+
+-- GHC 9.10 introduces exception annotations
+-- NOTE: in this version, `catch` does not decorate the caught exceptions with `WhileHandling`
+-- for this reason, `catch` behaves like `catchNoPropagate` in GHC 9.12 onwards
+#if defined(MIN_VERSION_GLASGOW_HASKELL) && MIN_VERSION_GLASGOW_HASKELL(9, 10, 0, 0)
+
+newtype Rethrow = Rethrow SomeException
+    deriving (Show)
+
+instance Base.Exception Rethrow where
+    fromException = Just . Rethrow
+    toException (Rethrow e) = e
+    backtraceDesired _ = False
+
+throwIO :: MonadIO m => SomeException -> m a
+throwIO e = liftIO (Base.throwIO (Rethrow e))
+
+-- earlier GHC versions do not support exception annotations
+#else
+
+throwIO :: MonadIO m => SomeException -> m a
+throwIO = liftIO . Base.throwIO
+
+#endif
+
+-- `catch` in GHC 9.10 and prior does not annotate the handler with `WhileHandling`
+-- therefore, we simply delegate to functions from `Control.Exception`
+
+try :: IO a -> IO (Either SomeException a)
+try = Base.try
+
+type RunInIO m = forall a. m a -> IO a
+
+handleUnliftUsing :: MonadIO n => RunInIO m -> (SomeException -> m a) -> m a -> n a
+handleUnliftUsing runInIO handler action
+  = liftIO (Base.handle (runInIO . handler) (runInIO action))
+
+#endif

--- a/src/Clang/LowLevel/Core.hs
+++ b/src/Clang/LowLevel/Core.hs
@@ -944,6 +944,8 @@ clang_visitChildren root visitor = liftIO $ do
     res <- onHaskellHeap root $ \parent' ->
       (/= 0) <$> wrap_visitChildren parent' visitor'
 
+    freeHaskellFunPtr visitor'
+
     readIORef eRef >>= \case
       Nothing  -> return res
       Just exc -> throwIO exc


### PR DESCRIPTION
Currently, the `Fold` API for `clang_visitChildren` uses `throwIO` to rethrow the captured `SomeException`, discarding all exception annotations in the process. To preserve the exception contexts, the exception must be rethrown with `ExceptionWithContext`.

This PR changes the `throwIO` wrapper in `Clang.HighLevel.Fold` as follows:
```haskell
throwIO :: MonadIO m => SomeException -> m a
throwIO e = liftIO (Base.rethrowIO (ExceptionWithContext (Base.someExceptionContext e) e))
```
To further avoid the `WhileHandling` annotations (making the whole `Fold` mechanism transparent to exceptions), `Base.try` and `handleUnliftUsing` are replaced with the following definitions:
```haskell
try :: IO a -> IO (Either SomeException a)
try m = Base.catchNoPropagate (Right <$> m) (\(ExceptionWithContext _ e) -> pure (Left e))
```
```haskell
handleUnliftUsing :: MonadIO n => RunInIO m -> (SomeException -> m a) -> m a -> n a
handleUnliftUsing runInIO handler action = liftIO $
    Base.catchNoPropagate (runInIO action) (\(ExceptionWithContext _ e) -> runInIO (handler e))
```
Note that `catchNoPropagate` is used here to avoid annotating the exception with `WhileHandling`. I have confirmed (by checking the implementation and by testing the new implementation) that the context in `ExceptionWithContext` is duplicated in the wrapped `SomeException`, so it is immediately discarded in `try` and recovered later in `throwIO`.

Due to subtle behaviour difference of `ExceptionWithContext` in GHC 9.10 (see comment below, https://github.com/well-typed/libclang/pull/60#issuecomment-4305304629), I use a custom rethrow wrapper `Rethrow` for GHC 9.10:
```haskell
newtype Rethrow = Rethrow SomeException
    deriving (Show)

instance Base.Exception Rethrow where
    fromException = Just . Rethrow
    toException (Rethrow e) = e
    backtraceDesired _ = False
```

I believe this should be a net improvement in ergonomics (for instance, the backtraces are kept as part of the exception context). However, this change is only compatible with newer GHC versions after the introduction of exception annotations. I know two possible solutions:
1. Use `CPP`. The three affected functions should probably be extracted to a separate internal module to minimise the impact of `CPP`;
2. Write two versions of the three functions in e.g., `src_new` and `src_old`, and use an `impl(ghc >= xxx)` condition in the Cabal file to switch between the two versions (`hs-source-dirs: src_new` and `hs-source-dirs: src_old`).

Please let me know if you would like to accept this change and what compatibility band-aid you prefer.