### PR TITLE
Remove `LLVM_CONFIG` configuration variable

### DIFF
--- a/libclang-bindings/CHANGELOG.md
+++ b/libclang-bindings/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Breaking changes
 
+* Removed `LLVM_CONFIG` configuration variable.  Configure `PATH` so that the
+  desired `llvm-config` is found instead.
+
 ### New features
 
 * Add a binding for `clang_isBeforeInTranslationUnit`. This function is only

--- a/libclang-bindings/configure
+++ b/libclang-bindings/configure
@@ -660,8 +660,8 @@ CC
 CLANG_INCLUDE_DIR
 CLANG_LIB_DIRS
 CLANG_LIB
-LLVM_PATH
 LLVM_CONFIG
+LLVM_PATH
 target_alias
 host_alias
 build_alias
@@ -710,7 +710,6 @@ with_so
       ac_precious_vars='build_alias
 host_alias
 target_alias
-LLVM_CONFIG
 LLVM_PATH
 CC
 CFLAGS
@@ -1340,7 +1339,6 @@ Optional Packages:
   --with-so=PATH          shared library to link to
 
 Some influential environment variables:
-  LLVM_CONFIG Location of llvm-config
   LLVM_PATH   Location of LLVM installation
   CC          C compiler command
   CFLAGS      C compiler flags
@@ -2340,7 +2338,16 @@ printf "%s\n" "$as_me: with library: $wt_user_lib" >&6;}
 esac
 
 
-# Extract the first word of "llvm-config", so it can be a program name with args.
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking LLVM resolution mode" >&5
+printf %s "checking LLVM resolution mode... " >&6; }
+if test -n "$LLVM_PATH" ; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: LLVM_PATH=$LLVM_PATH" >&5
+printf "%s\n" "LLVM_PATH=$LLVM_PATH" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: llvm-config" >&5
+printf "%s\n" "llvm-config" >&6; }
+  # Extract the first word of "llvm-config", so it can be a program name with args.
 set dummy llvm-config; ac_word=$2
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 printf %s "checking for $ac_word... " >&6; }
@@ -2385,26 +2392,17 @@ printf "%s\n" "no" >&6; }
 fi
 
 
-
-
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking LLVM resolution mode" >&5
-printf %s "checking LLVM resolution mode... " >&6; }
-if test -n "$LLVM_CONFIG" ; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: llvm-config" >&5
-printf "%s\n" "llvm-config" >&6; }
-else
-  if test -n "$LLVM_PATH" ; then
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: LLVM_PATH=$LLVM_PATH" >&5
-printf "%s\n" "LLVM_PATH=$LLVM_PATH" >&6; }
-  else
+  if test -z "$LLVM_CONFIG" ; then
     as_fn_error $? "llvm-config not found and LLVM_PATH not set" "$LINENO" 5
   fi
 fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking llvm-config version" >&5
 printf %s "checking llvm-config version... " >&6; }
-if test -n "$LLVM_CONFIG" ; then
+if test -n "$LLVM_PATH" ; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: skipped" >&5
+printf "%s\n" "skipped" >&6; }
+else
   wt_llvm_config_version="$("$LLVM_CONFIG" --version)"
   if test $? -eq 0 ; then
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $wt_llvm_config_version" >&5
@@ -2414,9 +2412,6 @@ printf "%s\n" "$wt_llvm_config_version" >&6; }
 printf "%s\n" "error" >&6; }
     as_fn_error $? "could not run llvm-config" "$LINENO" 5
   fi
-else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: skipped" >&5
-printf "%s\n" "skipped" >&6; }
 fi
 
 # WT_PARSE_VERSION(VERSION_STRING)
@@ -2546,10 +2541,10 @@ LIBS="${LIBS} -l${wt_clang_lib}"
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking LLVM library directories" >&5
 printf %s "checking LLVM library directories... " >&6; }
-if test -n "$LLVM_CONFIG" ; then
-  wt_clang_lib_dirs="$("$LLVM_CONFIG" --libdir)"
-else
+if test -n "$LLVM_PATH" ; then
   wt_clang_lib_dirs="${LLVM_PATH}/lib"
+else
+  wt_clang_lib_dirs="$("$LLVM_CONFIG" --libdir)"
 fi
 if test -n "$wt_user_lib_dir" && test "$wt_user_lib_dir" != "$wt_clang_lib_dirs"; then
   LDFLAGS="${LDFLAGS} -L${wt_user_lib_dir} -L${wt_clang_lib_dirs}"
@@ -2564,10 +2559,10 @@ CLANG_LIB_DIRS="$wt_clang_lib_dirs"
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking LLVM include directory" >&5
 printf %s "checking LLVM include directory... " >&6; }
-if test -n "$LLVM_CONFIG" ; then
-  wt_clang_include_dir="$("$LLVM_CONFIG" --includedir)"
-else
+if test -n "$LLVM_PATH" ; then
   wt_clang_include_dir="${LLVM_PATH}/include"
+else
+  wt_clang_include_dir="$("$LLVM_CONFIG" --includedir)"
 fi
 CPPFLAGS="${CPPFLAGS} -I${wt_clang_include_dir}"
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $wt_clang_include_dir" >&5

--- a/libclang-bindings/configure.ac
+++ b/libclang-bindings/configure.ac
@@ -48,27 +48,21 @@ case "$wt_with_so_path" in
     ;;
 esac
 
-dnl LLVM_CONFIG variable: Users may use this to specify which llvm-config
-dnl executable to use.
-AC_ARG_VAR(LLVM_CONFIG, [Location of llvm-config])
-AC_PATH_PROG([LLVM_CONFIG],[llvm-config],[])
-
-dnl LLVM_PATH variable: Users may alternatively specify the location of
-dnl an LLVM installation.
+dnl LLVM_PATH variable: This argument allows users to specify the location of
+dnl an LLVM installation, in which case llvm-config is not used.
 AC_ARG_VAR(LLVM_PATH, [Location of LLVM installation])
 
 dnl LLVM resolution:
-dnl 1. Use llvm-config specified by LLVM_CONFIG if set
+dnl 1. Use LLVM_PATH if set
 dnl 2. Use llvm-config in PATH if found
-dnl 3. Use LLVM_PATH if set
-dnl 4. Fail
+dnl 3. Fail if LLVM_PATH not set and llvm-config not in PATH
 AC_MSG_CHECKING([LLVM resolution mode])
-if test -n "$LLVM_CONFIG" ; then
-  AC_MSG_RESULT([llvm-config])
+if test -n "$LLVM_PATH" ; then
+  AC_MSG_RESULT([LLVM_PATH=$LLVM_PATH])
 else
-  if test -n "$LLVM_PATH" ; then
-    AC_MSG_RESULT([LLVM_PATH=$LLVM_PATH])
-  else
+  AC_MSG_RESULT([llvm-config])
+  AC_PATH_PROG([LLVM_CONFIG],[llvm-config],[])
+  if test -z "$LLVM_CONFIG" ; then
     AC_MSG_ERROR([llvm-config not found and LLVM_PATH not set])
   fi
 fi
@@ -76,7 +70,9 @@ fi
 dnl If using llvm-config, get the version.  This also checks that we can run
 dnl llvm-config.
 AC_MSG_CHECKING([llvm-config version])
-if test -n "$LLVM_CONFIG" ; then
+if test -n "$LLVM_PATH" ; then
+  AC_MSG_RESULT([skipped])
+else
   wt_llvm_config_version="$("$LLVM_CONFIG" --version)"
   if test $? -eq 0 ; then
     AC_MSG_RESULT([$wt_llvm_config_version])
@@ -84,8 +80,6 @@ if test -n "$LLVM_CONFIG" ; then
     AC_MSG_RESULT([error])
     AC_MSG_ERROR([could not run llvm-config])
   fi
-else
-  AC_MSG_RESULT([skipped])
 fi
 
 # WT_PARSE_VERSION(VERSION_STRING)
@@ -216,10 +210,10 @@ dnl LLVM library directory resolution:
 dnl 1. Use llvm-config or LLVM_PATH to determine the real library directory
 dnl 2. Append user-specified library directory if --with-so is used
 AC_MSG_CHECKING([LLVM library directories])
-if test -n "$LLVM_CONFIG" ; then
-  wt_clang_lib_dirs="$("$LLVM_CONFIG" --libdir)"
-else
+if test -n "$LLVM_PATH" ; then
   wt_clang_lib_dirs="${LLVM_PATH}/lib"
+else
+  wt_clang_lib_dirs="$("$LLVM_CONFIG" --libdir)"
 fi
 dnl LDFLAGS environment variable is set for checks below
 if test -n "$wt_user_lib_dir" && test "$wt_user_lib_dir" != "$wt_clang_lib_dirs"; then
@@ -234,10 +228,10 @@ AC_SUBST([CLANG_LIB_DIRS], ["$wt_clang_lib_dirs"])
 dnl LLVM include directory resolution logic:
 dnl 1. Use llvm-config or LLVM_PATH to determine the include directory
 AC_MSG_CHECKING([LLVM include directory])
-if test -n "$LLVM_CONFIG" ; then
-  wt_clang_include_dir="$("$LLVM_CONFIG" --includedir)"
-else
+if test -n "$LLVM_PATH" ; then
   wt_clang_include_dir="${LLVM_PATH}/include"
+else
+  wt_clang_include_dir="$("$LLVM_CONFIG" --includedir)"
 fi
 dnl CPPFLAGS environment variable is set for checks below
 CPPFLAGS="${CPPFLAGS} -I${wt_clang_include_dir}"

--- a/manual/README.md
+++ b/manual/README.md
@@ -98,11 +98,6 @@ library directories.  If you have more than one version of LLVM/Clang installed,
 you can configure your `PATH` to ensure that the `llvm-config` for the version
 that you want to use is found.
 
-Alternatively, you can configure the `LLVM_CONFIG` environment variable to the
-path of the `llvm-config` that you want to use.  If you use this environment
-variable, it should remain set while using `libclang-bindings`, not just during
-configuration.
-
 ### Using `LLVM_PATH`
 [t:using-llvm-path]: #using-llvm_path
 
@@ -366,8 +361,8 @@ environment used for building the package.
 
 * The `PATH` must resolve the same LLVM/Clang executables (and `.DLL` files on
   Windows) as when the library was built, modulo patch upgrades.
-* If `LLVM_CONFIG` or `LLVM_PATH` are used when building, they must also be set
-  when using the library.
+* If `LLVM_PATH` is used when building, it must also be set when using the
+  library.
 
 `cabal.project.local` configuration used to work around Cabal issues is required
 for any project that (directly or indirectly) uses `libclang-bindings`.


### PR DESCRIPTION
This commit removes the `LLVM_CONFIG` configuration variable.  Users should configure `PATH` so that the desired `llvm-config` is found. The motivation for this change is that we also use the `clang` executable.  It is expected behavior to find `clang` via `PATH` or `${LLVM_PATH}/bin`, while finding it via `LLVM_CONFIG` is potentially unexpected.

The logic is simplified.  `LLVM_PATH` is used if set.  Otherwise, `llvm-config` is used if found.  There is a configuration error if `LLVM_PATH` is not set and `llvm-config` is not found.

If users do not want to use `LLVM_PATH`, then it should not be set. Note that the `KyleMayes/install-llvm-action` action sets this environment variable.  (We will likely stop using that action in the future so that we can test new versions soon after they are released.)