### PR TITLE
Exception contexts

### DIFF
--- a/libclang-bindings/libclang-bindings.cabal
+++ b/libclang-bindings/libclang-bindings.cabal
@@ -103,6 +103,7 @@ library
     Clang.HighLevel.Wrappers
     Clang.Internal.ConstPtr
     Clang.Internal.CXString
+    Clang.Internal.Exception
     Clang.Internal.FFI
     Clang.Internal.Ptr
     Clang.Internal.Results

--- a/libclang-bindings/src/Clang/Backtrace.hs
+++ b/libclang-bindings/src/Clang/Backtrace.hs
@@ -70,7 +70,7 @@ collectBacktrace = return $ WrapStack callStack
 --
 -- > data CallFailed = CallFailed Backtrace
 -- >   deriving stock (Show)
--- >   deriving Exception via CollectedBacktrac CallFailed
+-- >   deriving Exception via CollectedBacktrace CallFailed
 newtype CollectedBacktrace a = CollectedBacktrace a
   deriving newtype Show
 

--- a/libclang-bindings/src/Clang/HighLevel/Fold.hs
+++ b/libclang-bindings/src/Clang/HighLevel/Fold.hs
@@ -4,6 +4,7 @@
 module Clang.HighLevel.Fold (
     -- * Folds
     Fold -- opaque
+  , HandlerResult(..)
   , Next -- opaque
     -- * Construction
   , simpleFold
@@ -26,7 +27,7 @@ module Clang.HighLevel.Fold (
   , clang_visitChildren
   ) where
 
-import Control.Exception (Exception (..), SomeException)
+import Control.Exception (Exception (..))
 import Control.Exception qualified as Base
 import Control.Monad (forM_)
 import Control.Monad.IO.Class (MonadIO, liftIO)
@@ -35,6 +36,7 @@ import Data.IORef
 import GHC.Stack
 
 import Clang.Enum.Simple
+import Clang.Internal.Exception
 import Clang.LowLevel.Core hiding (clang_visitChildren)
 import Clang.LowLevel.Core qualified as Core
 
@@ -53,7 +55,7 @@ import Clang.LowLevel.Core qualified as Core
 -- This provides for a much nicer user experience.
 data Fold m a = Fold{
       foldNext    :: CXCursor -> m (Next m a)
-    , foldHandler :: CXCursor -> SomeException -> m (Maybe a)
+    , foldHandler :: CXCursor -> ExactException -> m (HandlerResult (Maybe a))
     }
 
 -- | Construct simple fold
@@ -63,8 +65,8 @@ simpleFold :: forall m a. MonadIO m => (CXCursor -> m (Next m a)) -> Fold m a
 simpleFold foldNext =
     Fold{foldNext, foldHandler}
   where
-    foldHandler :: CXCursor -> SomeException -> m (Maybe a)
-    foldHandler _curr = liftIO . throwIO
+    foldHandler :: CXCursor -> ExactException -> m (HandlerResult (Maybe a))
+    foldHandler _curr _e = return HandlerRethrow
 
 -- | Fold with exception handler
 --
@@ -155,7 +157,7 @@ simpleFold foldNext =
 --
 -- > foldStruct :: Fold IO [Text]
 -- > foldStruct =
--- >     foldWithHandler (\_curr -> return . Just . hasUnexpectedField) $ \curr -> do
+-- >     foldWithHandler (\_curr -> return . HandlerResult . Just . hasUnexpectedField) $ \curr -> do
 -- >       -- .. body as before
 --
 -- With this handler in place, we will get the expected result
@@ -166,17 +168,17 @@ simpleFold foldNext =
 -- which behaves /as if/ the fold truly made recursive calls.
 foldWithHandler :: forall m e a.
      (MonadIO m, Exception e)
-  => (CXCursor -> e -> m (Maybe a)) -- ^ Exception handler
+  => (CXCursor -> e -> m (HandlerResult (Maybe a))) -- ^ Exception handler
   -> (CXCursor -> m (Next m a))
   -> Fold m a
 foldWithHandler handler foldNext =
     Fold{foldNext, foldHandler}
   where
-    foldHandler :: CXCursor -> SomeException -> m (Maybe a)
-    foldHandler curr e =
-        case fromException e of
+    foldHandler :: CXCursor -> ExactException -> m (HandlerResult (Maybe a))
+    foldHandler curr (WrapExactException se) =
+        case fromException se of
           Just e' -> handler curr e'
-          Nothing -> liftIO $ throwIO e
+          Nothing -> return HandlerRethrow
 
 -- | An exception that is caught during folding
 data FoldException e = FoldException {
@@ -203,15 +205,15 @@ foldTry foldNext = foldWithHandler handler foldNext'
 
     handler ::
          CXCursor
-      -> SomeException
-      -> m (Maybe (Either (FoldException e) a))
-    handler curr err
-      | Just e <- fromException @e err = do
-          pure $ Just $ Left $ FoldException {
+      -> ExactException
+      -> m (HandlerResult (Maybe (Either (FoldException e) a)))
+    handler curr (WrapExactException se)
+      | Just e <- fromException @e se = do
+          return $ HandlerResult $  Just $ Left $ FoldException {
               exception = e
             , cursor = curr
             }
-      | otherwise = liftIO $ throwIO err
+      | otherwise = return $ HandlerRethrow
 
 -- | Result of visiting one node
 --
@@ -302,29 +304,8 @@ instance Functor m => Functor (Next m) where
 instance Functor m => Functor (Fold m) where
   fmap f Fold{foldNext, foldHandler} = Fold{
         foldNext    = \curr -> fmap (fmap f) $ foldNext curr
-      , foldHandler = \curr -> fmap (fmap f) . foldHandler curr
+      , foldHandler = \curr -> fmap (fmap (fmap f)) . foldHandler curr
       }
-
-{-------------------------------------------------------------------------------
-  Internal: exception handling
-
-  We do not use @handle@ from @unlift@, as it excludes async exceptions, and we
-  want it to be up to the exception handler to decide if it wants to deal with
-  async exceptions or not.
--------------------------------------------------------------------------------}
-
-throwIO :: (MonadIO m, Exception e) => e -> m a
-throwIO = liftIO . Base.throwIO
-
-type RunInIO m = forall a. m a -> IO a
-
-handleUnliftUsing ::
-     ( MonadIO n
-     , Exception e
-     )
-  => RunInIO m -> (e -> m a) -> m a -> n a
-handleUnliftUsing runInIO handler action = liftIO $
-    Base.handle (runInIO . handler) (runInIO action)
 
 {-------------------------------------------------------------------------------
   Internal: partial results
@@ -333,7 +314,7 @@ handleUnliftUsing runInIO handler action = liftIO $
   the clang C library. They do not need to be (nor are) thread safe.
 -------------------------------------------------------------------------------}
 
-type PartialResults a = IORef (Either SomeException [a])
+type PartialResults a = IORef (Either ExactException [a])
 
 newPartialResults :: IO (PartialResults a)
 newPartialResults = newIORef (Right [])
@@ -345,7 +326,7 @@ addPartialResult ref x = do
       Left  oldErr -> unexpectedException oldErr
       Right xs     -> writeIORef ref $ Right (x:xs)
 
-recordException :: HasCallStack => PartialResults a -> SomeException -> IO ()
+recordException :: HasCallStack => PartialResults a -> ExactException -> IO ()
 recordException ref newErr = do
     mResults <- readIORef ref
     case mResults of
@@ -362,7 +343,7 @@ recordException ref newErr = do
 -- propagate (it will be caught in the low-level 'Core.clang_visitChildren'
 -- function). However, that's okay: if this @error@ ever triggers, it indicates
 -- a bug in this infrastructure, which can't really be handlded anyway.
-unexpectedException :: HasCallStack => SomeException -> IO a
+unexpectedException :: HasCallStack => ExactException -> IO a
 unexpectedException oldErr = error $ concat [
       "The impossible happened: we break at the first exception, "
     , "yet here we are: " ++ show oldErr ++ ".\n"
@@ -373,7 +354,7 @@ getPartialResults :: MonadIO m => PartialResults a -> m [a]
 getPartialResults ref = liftIO $ do
     mResults <- readIORef ref
     case mResults of
-      Left  e  -> throwIO e
+      Left  e  -> throwExact e
       Right xs -> return (reverse xs)
 
 partialResultsIsException :: PartialResults a -> IO Bool
@@ -465,7 +446,7 @@ popUntil runInIO someStack newParent = do
             Bottom _ ->
               error "popUntil: something has gone horribly wrong"
             Push p summarize (stack' :: Stack m b) -> do
-              let handler :: SomeException -> m (Maybe b)
+              let handler :: ExactException -> m (HandlerResult (Maybe b))
                   handler = foldHandler (topFold stack') (parent p)
               mb <- Base.try $
                 handleUnliftUsing runInIO handler $
@@ -508,7 +489,7 @@ clang_visitChildren root topLevelFold = withRunInIO $ \runInIO -> do
         popUntil runInIO someStack parent
         SomeStack (stack :: Stack m x) <- readIORef someStack
 
-        let foldHandler    :: CXCursor -> SomeException -> m (Maybe x)
+        let foldHandler    :: CXCursor -> ExactException -> m (HandlerResult (Maybe x))
             foldNext       :: CXCursor -> m (Next m x)
             partialResults :: PartialResults x
             Processing{
@@ -521,7 +502,7 @@ clang_visitChildren root topLevelFold = withRunInIO $ \runInIO -> do
           return $ simpleEnum CXChildVisit_Continue
         else do
           next <- Base.try $
-            handleUnliftUsing runInIO (fmap Continue . foldHandler current) $
+            handleUnliftUsing runInIO (fmap (fmap Continue) . foldHandler current) $
               foldNext current
           case next of
             Right (Break ma) -> do

--- a/libclang-bindings/src/Clang/HighLevel/Types.hs
+++ b/libclang-bindings/src/Clang/HighLevel/Types.hs
@@ -24,6 +24,7 @@ module Clang.HighLevel.Types (
   , diagnosticIsError
     -- * Folds
   , Fold
+  , HandlerResult(..)
   , Next
     -- ** Construction
   , simpleFold

--- a/libclang-bindings/src/Clang/Internal/Exception.hs
+++ b/libclang-bindings/src/Clang/Internal/Exception.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE CPP #-}
+module Clang.Internal.Exception (
+    ExactException(..)
+  , throwExact
+  , RunInIO
+  , HandlerResult(..)
+  , handleUnliftUsing
+  ) where
+
+import Control.Exception (Exception (..))
+import Control.Exception qualified as Base
+import Control.Monad.IO.Class (MonadIO (..))
+
+{-------------------------------------------------------------------------------
+  Internal: exception handling
+-------------------------------------------------------------------------------}
+
+-- | Newtype wrapper for throwing this /exact/ exception
+--
+-- In other words, including any exception annotations.
+newtype ExactException = WrapExactException {
+      unwrapExactException :: Base.SomeException
+    }
+  deriving stock (Show)
+
+instance Exception ExactException where
+  fromException    = Just . WrapExactException
+  toException      = unwrapExactException
+  displayException = displayException . unwrapExactException
+#if MIN_VERSION_base(4,20,0)
+  backtraceDesired = const False
+#endif
+
+-- | Type-specialized wrapper around throwIO, to avoid mistakes
+--
+-- Implementation note: does not need a 'HasCallStack' constraint, because
+-- no new backtrace is added.
+throwExact :: ExactException -> IO a
+throwExact = Base.throwIO
+
+type RunInIO m = forall a. m a -> IO a
+
+-- | Exception handler result
+--
+-- This generalizes two functions:
+--
+-- * 'handle' through 'HandlerResult'
+-- * 'onException' through 'HandlerRethrow'
+--
+-- See 'handleUnliftUsing'.
+data HandlerResult a =
+    -- | Handler dealt with the exception and computed a new result
+    HandlerResult a
+
+    -- | Handler dealt with the exception, perhaps freeing some resources,
+    -- and wants to rethrow the original exception.
+    --
+    -- This mimicks the behaviour of 'onException'.
+  | HandlerRethrow
+  deriving stock (Show, Functor)
+
+-- | Generalized 'handle'
+--
+-- If the exception handler throws an exception of its own, instead of returning
+-- a result, a 'WhileHandling' annotation is added to that exception recording
+-- the original exception that was being handled (in GHC >= 9.12).
+--
+-- Implementation note: We do not use @handle@ from @unlift@, as it excludes
+-- async exceptions, and we want it to be up to the exception handler to decide
+-- if it wants to deal with async exceptions or not.
+handleUnliftUsing ::
+     MonadIO n
+  => RunInIO m
+  -> (ExactException -> m (HandlerResult a))
+  -> m a -> n a
+handleUnliftUsing runInIO handler action = liftIO $
+        Base.handle
+          (\e -> Left . (e,) <$> runInIO (handler e))
+          (Right <$> runInIO action)
+    >>= aux
+  where
+    aux :: Either (ExactException, HandlerResult a) a -> IO a
+    aux = \case
+        Right a -> return a
+        Left (e, handlerResult) ->
+          case handlerResult of
+            HandlerResult a -> return a
+            HandlerRethrow  -> throwExact e
+

--- a/libclang-bindings/src/Clang/LowLevel/Core.hs
+++ b/libclang-bindings/src/Clang/LowLevel/Core.hs
@@ -251,6 +251,7 @@ import Clang.Enum.Simple
 import Clang.Internal.ByValue
 import Clang.Internal.ConstPtr (ConstPtr (ConstPtr, unConstPtr))
 import Clang.Internal.CXString ()
+import Clang.Internal.Exception
 import Clang.Internal.FFI
 import Clang.Internal.Ptr (safeCastPtr)
 import Clang.Internal.Results
@@ -930,23 +931,24 @@ clang_visitChildren ::
      -- returning 'CXChildVisit_Break'.
 clang_visitChildren root visitor = liftIO $ do
     -- reference cell for a possible exception thrown by 'visitor'.
-    eRef <- newIORef Nothing
-
-    visitor' <- mkCursorVisitor $ \current parent -> do
-      current' <- CXCursor <$> copyToHaskellHeap current
-      parent'  <- CXCursor <$> copyToHaskellHeap parent
-      try (visitor current' parent') >>= \case
-        Left exc -> do
-          writeIORef eRef (Just (exc :: SomeException))
-          return (simpleEnum CXChildVisit_Break)
-        Right x -> return x
-
-    res <- onHaskellHeap root $ \parent' ->
-      (/= 0) <$> wrap_visitChildren parent' visitor'
-
+    eRef :: IORef (Maybe ExactException) <- newIORef Nothing
+    res  :: Bool <-
+      bracket (mkCursorVisitor $ aux eRef) freeHaskellFunPtr $ \visitor' ->
+        onHaskellHeap root $ \parent' ->
+          (/= 0) <$> wrap_visitChildren parent' visitor'
     readIORef eRef >>= \case
       Nothing  -> return res
-      Just exc -> throwIO exc
+      Just exc -> throwExact exc
+  where
+    aux :: IORef (Maybe ExactException) -> WrapCXCursorVisitor
+    aux eRef current parent = do
+        current' <- CXCursor <$> copyToHaskellHeap current
+        parent'  <- CXCursor <$> copyToHaskellHeap parent
+        try (visitor current' parent') >>= \case
+          Left exc -> do
+            writeIORef eRef (Just (exc :: ExactException))
+            return (simpleEnum CXChildVisit_Break)
+          Right x -> return x
 
 {-------------------------------------------------------------------------------
   Cross-referencing in the AST

--- a/libclang-bindings/test/Test/Test/Exceptions.hs
+++ b/libclang-bindings/test/Test/Test/Exceptions.hs
@@ -114,7 +114,7 @@ demo3 = do
   where
     foldStruct :: Fold IO [Text]
     foldStruct =
-        foldWithHandler (\_curr -> return . Just . hasUnexpectedField) $ \curr -> do
+        foldWithHandler (\_curr -> return . HandlerResult . Just . hasUnexpectedField) $ \curr -> do
           kind <- fromSimpleEnum <$> clang_getCursorKind curr
           case kind of
             Right CXCursor_StructDecl ->

--- a/libclang-bindings/test/Test/Util/FoldException.hs
+++ b/libclang-bindings/test/Test/Util/FoldException.hs
@@ -57,10 +57,10 @@ descrTopLevel ex = AST.Descr $
     show ex ++ " at top-level"
 
 -- | Handler intended for use in folds
-handleAt :: CXCursor -> FoldException -> IO (Maybe (AST.Node AST.Descr))
+handleAt :: CXCursor -> FoldException -> IO (HandlerResult (Maybe (AST.Node AST.Descr)))
 handleAt curr ex = do
     node <- AST.descrAt curr
-    return $ Just $ AST.Node (descrAt node ex) $ AST.Siblings []
+    return $ HandlerResult $ Just $ AST.Node (descrAt node ex) $ AST.Siblings []
 
 -- | Top-level handler
 --
@@ -130,12 +130,12 @@ fold infoForCursor = go
                 Just n  -> Exception.throwIO $ FoldException n
                 Nothing -> return $ AST.Node node (AST.Siblings children)
 
-    handler :: CXCursor -> FoldException -> IO (Maybe (AST.Node AST.Descr))
+    handler :: CXCursor -> FoldException -> IO (HandlerResult (Maybe (AST.Node AST.Descr)))
     handler curr e = do
         info <- infoForCursor curr
         if exceptionHandler info
           then handleAt curr e
-          else Exception.throwIO e
+          else return HandlerRethrow
 
 parse :: (CXCursor -> IO Info) -> TestInput -> IO (AST AST.Descr)
 parse infoForCursor input =


### PR DESCRIPTION
Supersedes #60 .

@ruifengx In this PR I have taken the various ideas from your PR (#60), and combined them with some work I did another project, as well as applied all the various insights that I learned while trying to make sense of the situation regarding exception annotations (which led to my blog post [Exception Annotations: Lay of the Land](https://well-typed.com/blog/2026/05/lay-annotation-land/)).

The technical details of the PR looks quite a bit different from yours, but its essence is still there. There is one important different in approach though. In your version of `handleUnliftUsing`, you were explicitly using `catchNoPropagate` and `rethrowIO`. Initially I did not understand why you opted for this, but then I realized that without that, `simpleFold`, `foldWithHandler` and `foldTry` would all add unnecessary `WhileHandling` annotations because they all rethrow the exception (unconditionally in `simpleFold` and when the cast fails in `foldWithHandler` and `foldTry`). And I agree: unnecessary `WhileHandling` annotations result in a lot of unnecessary noise, making backtraces more difficult to read than needed (for example, I submitted a [patch against async](https://github.com/simonmar/async/pull/185) a few days ago for the same reason). 

_However_, if the exception handler _itself_ throws a (different) exception, then not adding the `WhileHandling` exception means that we lose the original exception, and its annotations: that's bad. So we want some kind of combination of `handle` and `onException`; I tackled this problem by changing the type of the handler result: the handler can now distinguish between (1) returning a normal result, (2) throwing a new exception (which will get a `WhileHandling` annotaiton), or (3) indicating that the original exception should be rethrown (without a `WhileHandling` annotation).

The other changes are more minor:

* I renamed your `Rethrow` newtype wrapper to `ExactException`; this is a pattern I recently starting adopting in [`grapesy`](https://github.com/well-typed/grapesy/blob/main/grapesy/src/Network/GRPC/Common/Exception.hs), and I find it quite useful; it emphasises "this exact exception, and not some variant of it with annotations altered". The nice thing is that this can be defined almost without CPP and it will work across all GHC versions.
* I no longer use `SomeException` anywhere anymore now; it's always `ExactException`, with `throwExact` as a helper to avoid mistakes. I consider throwing `SomeException` a red flag these days; in your version, you basically _fixed_ `throwIO` instead, which also works, but I find this approach a bit more explicit.
* For `try` I think the version from `base` is just fine; although `catch` adds a `WhileHandling` annotations to exceptions thrown by the exception handler, `try` never throws, so this does not matter.
* This also means that the amount of CPP is now much less; there is very little anymore that is GHC dependent (though this critically depends on using `ExactException`).

Thanks for the fix for using `freeHaskellFunPtr`! (How did you even notice that?). I modified it slightly to use `bracket` instead.

Thanks again for your contribution :) We've added you to the list of contributors in https://github.com/well-typed/hs-bindgen/ . Let me know if anything in this PR looks wrong to you!

